### PR TITLE
Skills bug

### DIFF
--- a/src/app/profile/skills/SkillCarousel.jsx
+++ b/src/app/profile/skills/SkillCarousel.jsx
@@ -8,7 +8,7 @@ import { TtButton } from "@/app/TtButton/TtButton";
 import { useEffect, useState } from "react";
 import { SkillEntry } from "./SkillEntry";
 
-export const SkillsBox=()=>{
+export const SkillCarousel=()=>{
     const [currentSkill,setCurrentSkill]=useState(parseInt(sessionStorage.getItem("skill"))||0)
     const skill=skillList[currentSkill]
     const [upDown,setUpDown]=useState(null)

--- a/src/app/profile/skills/SkillEntry.jsx
+++ b/src/app/profile/skills/SkillEntry.jsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { proficiencyKey} from "@/skills";
+import styles from "./Skills.module.css";
+import { logGrowth } from "@/logGrowth";
+
+export const SkillEntry=({entry,ind,upDown,delayTransition})=>{
+    const titleStyle={
+        filter:`hue-rotate(${delayTransition?0:(entry.proficieny+1)*.25*180}deg)`,
+        transitionDelay:logGrowth[ind]+.5+"s",
+    }  
+    const barStyle={
+        width:entry.proficieny*25+25+"%",
+        filter:`hue-rotate(${delayTransition?0:(entry.proficieny+1)*.25*180}deg)`,
+        animationDelay:logGrowth[ind]+.5+"s",
+        transitionDelay:logGrowth[ind]+.5+"s"
+    }
+       
+    return (
+        <div className={styles.skill} key={entry.name}>
+        <div 
+            className={`${styles.title} ${upDown?styles.slideRight:styles.slideLeft}`}
+        >
+            <h3 
+                className={styles.skillName} 
+                style={titleStyle}
+            >
+                {entry.name}
+            </h3>
+            <span>{entry.years} yrs</span>
+        </div>
+            <div className={styles.progressBar}>
+                <span 
+                    className={styles.proficiency}
+                    style={{animationDelay:(logGrowth[ind]+1)+"s"}}
+                >
+                    {proficiencyKey[entry.proficieny]}
+                </span>
+                <div 
+                    className={styles.progress} 
+                    style={barStyle}        
+                />
+            </div>
+        </div>
+    )
+}

--- a/src/app/profile/skills/Skills.jsx
+++ b/src/app/profile/skills/Skills.jsx
@@ -1,23 +1,24 @@
 'use client'
 
-import { proficiencyKey, skills } from "@/skills";
+import { skills } from "@/skills";
 import styles from "./Skills.module.css";
 import ArrowBackIcon from '@mui/icons-material/ArrowBackIos';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForwardIos';
-import { logGrowth } from "@/logGrowth";
 import { TtButton } from "@/app/TtButton/TtButton";
 import { useEffect, useState } from "react";
+import { SkillEntry } from "./SkillEntry";
 
 export const SkillsBox=()=>{
-    const [currentSkill,setCurrentSkill]=useState(0)
+    const [currentSkill,setCurrentSkill]=useState(parseInt(sessionStorage.getItem("skill"))||0)
     const skill=skillList[currentSkill]
     const [upDown,setUpDown]=useState(null)
-    const [profficiencies,setProfficiencies]=useState(null)
+    const [delayTransition,setDelayTranstition]=useState(true)
+
     const cycleSkill=(upDown)=>{
         const ind=getInd(upDown)
         setCurrentSkill(ind)
-        setProfficiencies(null)
-        sessionStorage.setItem("skill",skillList[ind])
+        setDelayTranstition(true)
+        sessionStorage.setItem("skill",ind)
         setUpDown(upDown>0)
     }
     const getInd=(upDown)=>{
@@ -27,13 +28,14 @@ export const SkillsBox=()=>{
     }
 
     useEffect(()=>{
-        const stored=sessionStorage.getItem("skill")
-        if(stored)setCurrentSkill(skillList.indexOf(stored))
-    })
-
-    useEffect(()=>{
-        setTimeout(()=>{setProfficiencies(skills[skill].map((entry)=>entry.proficieny))},250)
+        /**
+         * no transition if css prop changed on render; need to delay setting 
+         * elem style filter:(rotateHue deg) for hue transition;
+         * cannot hardcode as keyframes in css module because deg is dynamic
+         */
+        setTimeout(()=>{setDelayTranstition(false)},250)
     },[currentSkill])
+
     return(
         <div className={styles.container}>
             <h1
@@ -52,43 +54,16 @@ export const SkillsBox=()=>{
                 />
                 <div className={styles.skillContent}>
                 {
-                    skills[skill].map((entry,ind)=>{
-                        return (
-                            <div className={styles.skill} key={entry.name}>
-                            <div 
-                                className={`${styles.title} ${styles[upDown?"slideRight":"slideLeft"]}`}
-                            >
-                                <h3 
-                                    className={styles.skillName} 
-                                    style={{
-                                        filter:`hue-rotate(${!profficiencies?0:(profficiencies[ind]+1)*.25*180}deg)`,
-                                        transitionDelay:logGrowth[ind]+.5+"s",
-                                    }}
-                                >
-                                    {entry.name}
-                                </h3>
-                                <span>{entry.years} yrs</span>
-                            </div>
-                                <div className={styles.progressBar}>
-                                    <span 
-                                        className={styles.proficiency}
-                                        style={{animationDelay:(logGrowth[ind]+1)+"s"}}
-                                    >
-                                        {proficiencyKey[entry.proficieny]}
-                                    </span>
-                                    <div 
-                                        className={styles.progress} 
-                                        style={{
-                                            width:entry.proficieny*25+25+"%",
-                                            filter:`hue-rotate(${!profficiencies?0:(profficiencies[ind]+1)*.25*180}deg)`,
-                                            animationDelay:logGrowth[ind]+.5+"s",
-                                            transitionDelay:logGrowth[ind]+.5+"s"
-                                        }}        
-                                    />
-                                </div>
-                            </div>
-                        )
-                })}
+                    skills[skill].map((entry,ind) => 
+                        <SkillEntry key={`${entry.name}_entry`} 
+                        {...{
+                            entry, 
+                            ind, 
+                            upDown, 
+                            delayTransition
+                        }}    
+                        />
+                )}
                 </div>
                 <TtButton
                     className={styles.cycleButton} 

--- a/src/app/profile/skills/Skills.jsx
+++ b/src/app/profile/skills/Skills.jsx
@@ -54,15 +54,15 @@ export const SkillsBox=()=>{
                 />
                 <div className={styles.skillContent}>
                 {
-                    skills[skill].map((entry,ind) => 
-                        <SkillEntry key={`${entry.name}_entry`} 
-                        {...{
-                            entry, 
-                            ind, 
-                            upDown, 
-                            delayTransition
-                        }}    
-                        />
+                skills[skill].map((entry,ind) => 
+                    <SkillEntry key={`${entry.name}_entry`} 
+                    {...{
+                        entry, 
+                        ind, 
+                        upDown, 
+                        delayTransition
+                    }}    
+                    />
                 )}
                 </div>
                 <TtButton

--- a/src/app/profile/skills/layout.js
+++ b/src/app/profile/skills/layout.js
@@ -1,10 +1,9 @@
-import { AboutMe } from "../aboutme/AboutMe";
-import { SkillsBox } from "./Skills";
+import { SkillCarousel } from "./SkillCarousel";
 
 export default function SkillsLayout({children}) {
     return (
       <section>
-        <SkillsBox/>
+        <SkillCarousel/>
       </section>
     )
   }

--- a/src/app/profile/workhistory/WorkEntry.jsx
+++ b/src/app/profile/workhistory/WorkEntry.jsx
@@ -2,11 +2,10 @@ import { logGrowth } from "@/logGrowth"
 import styles from "./WorkHistory.module.css"
 import RemoveIcon from '@mui/icons-material/Remove';
 import AddIcon from '@mui/icons-material/Add';
-import { useState } from "react";
 import { TtButton } from "../../TtButton/TtButton";
+
 export const WorkEntry=({entry,ind,expanded,trackExpanded})=>{
-    // const [collapsed,setCollapsed]=useState(false)
-    const toggleCollapsed=()=>{
+    const toggleExpanded=()=>{
         trackExpanded(ind,!expanded)
     }
 
@@ -19,7 +18,7 @@ export const WorkEntry=({entry,ind,expanded,trackExpanded})=>{
             <h2>{entry.title}</h2>
             <TtButton 
                 className={styles.toggleCollapse}
-                onClick={toggleCollapsed}
+                onClick={toggleExpanded}
                 icon={expanded?<RemoveIcon/>:<AddIcon/>}
                 tooltip={expanded?"collapse":"expand"}
             />
@@ -30,7 +29,7 @@ export const WorkEntry=({entry,ind,expanded,trackExpanded})=>{
                 style={{animationDelay:0.75+logGrowth[ind*2]+"s"}}
             >
             {
-                entry.responsibilities.map( (bullet,ind) =>
+            entry.responsibilities.map( (bullet,ind) =>
                 <li key={`${entry.company}_bullet${ind}`}>
                     {bullet}
                 </li>)
@@ -38,5 +37,4 @@ export const WorkEntry=({entry,ind,expanded,trackExpanded})=>{
             </ul>
         </div>
     )
-
 }

--- a/src/app/profile/workhistory/WorkHistory.jsx
+++ b/src/app/profile/workhistory/WorkHistory.jsx
@@ -5,7 +5,6 @@ import styles from "./WorkHistory.module.css"
 import { WorkEntry } from "./workEntry";
 import { useEffect, useState } from "react";
 
-
 export const WorkHistory=()=>{
     const stored=sessionStorage.getItem("expanded-entries")
     const [expanded,setExpanded]=useState(stored?JSON.parse(stored):workHistory.map(()=>true))
@@ -14,16 +13,25 @@ export const WorkHistory=()=>{
         prevExpanded.splice(ind,1,bool)
         setExpanded(prevExpanded)
     }
-    useEffect(()=>{
-        storeExpanded(expanded)
-    },[expanded])
-
     const storeExpanded=(exp)=>sessionStorage.setItem("expanded-entries",JSON.stringify(exp))
+    
+    useEffect(() => { storeExpanded(expanded) }, [expanded])
+
     return(
         <div className={styles.container}>
             <h1>Work History</h1>
             <div className={styles.entries}>
-                {workHistory.map((entry,ind)=><WorkEntry key={`${entry.company}_entry`} {...{entry,ind,expanded:expanded[ind],trackExpanded}}/>)}
+                {
+                workHistory.map((entry,ind)=>
+                <WorkEntry key={`${entry.company}_entry`} 
+                {...{
+                    entry,
+                    ind,
+                    expanded:expanded[ind],
+                    trackExpanded
+                }}
+                />)
+                }
             </div>
         </div>
         

--- a/src/app/profile/workhistory/layout.js
+++ b/src/app/profile/workhistory/layout.js
@@ -1,6 +1,5 @@
 import { WorkHistory } from "./WorkHistory";
 
-
 export default function WorkHistoryLayout({children}) {
     return (
       <section>


### PR DESCRIPTION
Skill carousel was intended to load from session storage on tab change and refresh. Refresh loaded default (languages) and then switched to stored skills section after render. Fixed bug; see commit messages for detail.